### PR TITLE
Fix url (#172)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ FROM tomcat:$IMAGE_VERSION
 
 LABEL maintainer="Tim Sutton<tim@linfiniti.com>"
 
-ARG GS_VERSION=2.17.1
+ARG GS_VERSION=2.17.2
 
 ARG WAR_URL=http://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/geoserver-${GS_VERSION}-war.zip
-ARG STABLE_PLUGIN_URL=https://liquidtelecom.dl.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/extensions
+ARG STABLE_PLUGIN_URL=https://sourceforge.net/projects/geoserver/files/GeoServer/${GS_VERSION}/extensions
 
 #Install extra fonts to use with sld font markers
 RUN apt-get -y update; apt-get install -y fonts-cantarell lmodern ttf-aenigma ttf-georgewilliams ttf-bitstream-vera \


### PR DESCRIPTION
* bump geoserver to 2.17.1

* fix names in plugin download text file

* change url and upgrade to geoserver 2.17.2

Co-authored-by: admire <admire@kartoza.com>